### PR TITLE
画面上で初期画面のセルを表示できるようにする

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,19 @@
+// App.tsx
 import React from "react";
-import Game from "./components/Game/Board";
 import Header from "./components/Header/Header";
-import "./styles/App.css";
+import Board from "./components/Game/Board";
 
 const App: React.FC = () => {
+  const boardProps = {
+    cellRows: 12,
+    cellCols: 18,
+    bombs: 40,
+  };
+
   return (
     <div className="App">
       <Header />
-      <Game />
+      <Board {...boardProps} />
     </div>
   );
 };

--- a/src/components/Game/Board.tsx
+++ b/src/components/Game/Board.tsx
@@ -1,11 +1,53 @@
-import React from 'react';
+// Board.tsx
+import React, { useEffect, useState } from "react";
+import Cell from "./Cell";
 
-const Board: React.FC = () => {
-  return (
-    <div className="Board">
-
-    </div>
-  );
+export interface BoardProps {
+  cellRows: number;
+  cellCols: number;
+  bombs: number;
 }
+
+const Board: React.FC<BoardProps> = ({ cellRows, cellCols, bombs }) => {
+  const [cells, setCells] = useState<
+    Array<{
+      isOpened: boolean;
+      isBomb: boolean;
+      isFragged: boolean;
+      count: number;
+    }>
+  >([]);
+
+  useEffect(() => {
+    const initialCells = Array.from({ length: cellRows * cellCols }, () => ({
+      isOpened: true,
+      isBomb: false,
+      isFragged: false,
+      count: 0,
+    }));
+
+    const bombIndices: Set<number> = new Set();
+    while (bombIndices.size < bombs) {
+      const randomIndex = Math.floor(Math.random() * (cellCols * cellRows));
+      bombIndices.add(randomIndex);
+    }
+    bombIndices.forEach((index) => (initialCells[index].isBomb = true));
+    setCells(initialCells);
+  }, [cellRows, cellCols, bombs]);
+
+  const renderCells = () => {
+    return cells.map((cell, index) => (
+      <Cell
+        key={index}
+        isOpend={cell.isOpened}
+        isBomb={cell.isBomb}
+        isFragged={cell.isFragged}
+        count={cell.count}
+      />
+    ));
+  };
+
+  return <div className="Board">{renderCells()}</div>;
+};
 
 export default Board;

--- a/src/components/Game/Cell.tsx
+++ b/src/components/Game/Cell.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import "../../styles/App.css";
 
 interface CellProps {
   isOpend: boolean;

--- a/src/styles/App.css
+++ b/src/styles/App.css
@@ -1,0 +1,18 @@
+.Cell {
+  width: 30px;
+  height: 30px;
+  border: 1px solid #ccc;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 14px;
+}
+
+.Cell.opened {
+  background-color: #eee;
+}
+
+.Board {
+  display: grid;
+  grid-template-columns: repeat(18, 30px);
+}


### PR DESCRIPTION
## 概要
画面上でセルを初期表示できるようにしました。
初回読み込み時に爆弾をランダムで配置し、セルを18*12で表示させています。
